### PR TITLE
Week0 setup with Poetry and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4      # 拉取仓库代码
-      - uses: actions/setup-python@v5  # 安装 Python 3.12
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
-      - run: pip install -r requirements.txt
-      - run: pytest -v                 # 运行单元测试
+          python-version: '3.12'
+      - uses: snok/install-poetry@v1
+      - run: poetry install --no-interaction
+      - run: poetry run pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+poetry.lock
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# RPG_story_generator
+# RPG Story Generator
+
+This repository hosts the development of a logic-driven suspense RPG generator.
+
+```
+/core   - Python backend implementation
+/webui  - Next.js frontend (placeholder)
+/docs   - Project documentation
+```

--- a/core/rpggen/__init__.py
+++ b/core/rpggen/__init__.py
@@ -1,0 +1,2 @@
+__all__ = ["main"]
+from .cli import main

--- a/core/rpggen/cli.py
+++ b/core/rpggen/cli.py
@@ -1,0 +1,7 @@
+import typer
+
+def main():
+    typer.echo("RPG Generator CLI placeholder")
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+Project docs will be placed here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[tool.poetry]
+name = "rpggen"
+version = "0.1.0"
+description = "Logic-driven suspense RPG generator"
+authors = ["RPG Team <team@example.com>"]
+packages = [
+    {include = "rpggen", from = "core"}
+]
+
+[tool.poetry.scripts]
+rpggen = "rpggen.cli:main"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+pydantic = ">=3"
+langchain = "*"
+typer = "*"
+pyyaml = "*"
+jinja2 = "*"
+faiss-cpu = "*"
+numpy = "*"
+networkx = "*"
+fastapi = "*"
+uvicorn = "*"
+
+[tool.poetry.dev-dependencies]
+pytest = "*"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,6 @@
+from rpggen import main
+
+def test_main_output(capsys):
+    main()
+    captured = capsys.readouterr()
+    assert "placeholder" in captured.out

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,3 @@
+# Web UI
+
+Placeholder for Next.js frontend.


### PR DESCRIPTION
## Summary
- initialize repo structure for core, webui, docs
- configure Poetry project and CLI skeleton
- add GitHub Actions CI using Poetry
- add placeholder unit test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6858a8efdef083248a1df0d87773844b