### PR TITLE
Implement base data models

### DIFF
--- a/core/rpggen/__init__.py
+++ b/core/rpggen/__init__.py
@@ -1,2 +1,6 @@
-__all__ = ["main"]
+from __future__ import annotations
+
 from .cli import main
+from . import models
+
+__all__ = ["main", "models"] + list(models.__all__)

--- a/core/rpggen/models/__init__.py
+++ b/core/rpggen/models/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .world import *
+from .character import *
+from .relation import *
+from .plot import *
+from .event import *
+from .flow import *
+from .script import *
+
+__all__ = []  # populated below
+
+# gather all names from imported modules
+for _name in list(locals().keys()):
+    if not _name.startswith("_") and _name[0].isupper():
+        __all__.append(_name)
+
+__all__ = sorted(set(__all__))

--- a/core/rpggen/models/character.py
+++ b/core/rpggen/models/character.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from pydantic import BaseModel, Field, PositiveInt
+from typing import List, Literal, Optional
+
+
+__all__ = ["Character"]
+
+
+class Character(BaseModel):
+    id: str = Field(..., pattern="^[a-z0-9_]+$")
+    name: str
+    aliases: Optional[List[str]] = None
+    faction_id: str
+    gender: Literal["male", "female", "nonbinary", "unknown"]
+    birth: PositiveInt
+    death: Optional[PositiveInt] = None
+    age: Optional[int] = None
+    occupation: str
+    personality: List[str]
+    values: List[str]
+    motives: List[str]
+    skills: List[str]
+    secrets: Optional[List[str]] = None
+    appearance: str
+    signature_items: Optional[List[str]] = None
+    backstory: str = Field(..., min_length=120, max_length=220)
+    relationship_seeds: Optional[List[str]] = None
+
+
+_schema_dir = Path(__file__).resolve().parent
+_schema_path = _schema_dir / "characters.schema.json"
+_schema_path.write_text(json.dumps(Character.model_json_schema(), indent=2))

--- a/core/rpggen/models/characters.schema.json
+++ b/core/rpggen/models/characters.schema.json
@@ -1,0 +1,175 @@
+{
+  "properties": {
+    "id": {
+      "pattern": "^[a-z0-9_]+$",
+      "title": "Id",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "aliases": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Aliases"
+    },
+    "faction_id": {
+      "title": "Faction Id",
+      "type": "string"
+    },
+    "gender": {
+      "enum": [
+        "male",
+        "female",
+        "nonbinary",
+        "unknown"
+      ],
+      "title": "Gender",
+      "type": "string"
+    },
+    "birth": {
+      "exclusiveMinimum": 0,
+      "title": "Birth",
+      "type": "integer"
+    },
+    "death": {
+      "anyOf": [
+        {
+          "exclusiveMinimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Death"
+    },
+    "age": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Age"
+    },
+    "occupation": {
+      "title": "Occupation",
+      "type": "string"
+    },
+    "personality": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Personality",
+      "type": "array"
+    },
+    "values": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Values",
+      "type": "array"
+    },
+    "motives": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Motives",
+      "type": "array"
+    },
+    "skills": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Skills",
+      "type": "array"
+    },
+    "secrets": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Secrets"
+    },
+    "appearance": {
+      "title": "Appearance",
+      "type": "string"
+    },
+    "signature_items": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Signature Items"
+    },
+    "backstory": {
+      "maxLength": 220,
+      "minLength": 120,
+      "title": "Backstory",
+      "type": "string"
+    },
+    "relationship_seeds": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Relationship Seeds"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "faction_id",
+    "gender",
+    "birth",
+    "occupation",
+    "personality",
+    "values",
+    "motives",
+    "skills",
+    "appearance",
+    "backstory"
+  ],
+  "title": "Character",
+  "type": "object"
+}

--- a/core/rpggen/models/event.py
+++ b/core/rpggen/models/event.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from pydantic import BaseModel, Field, conlist, confloat, PositiveInt
+from typing import List, Literal, Optional
+
+__all__ = ["Puzzle", "Event", "Events", "SceneType"]
+
+SceneType = Literal[
+    "dialogue",
+    "investigation",
+    "action",
+    "cinematic",
+    "flashback",
+]
+
+
+class Puzzle(BaseModel):
+    id: str = Field(..., pattern=r"^PUZ-\d{3}$")
+    puzzle_type: Literal["logic", "pattern", "riddle", "skill"]
+    description: str
+    solution: str
+    reward_clue: Optional[str] = None
+
+
+class Event(BaseModel):
+    id: str = Field(..., pattern=r"^E-\d{2}-\d{2}$")
+    beat_id: str
+    order: PositiveInt
+    scene_type: SceneType
+    title: str
+    synopsis: str = Field(..., min_length=40, max_length=120)
+    location: str
+    absolute_ts: Optional[str] = None
+    characters: conlist(str, min_length=1)
+    npcs: Optional[List[str]] = None
+    player_role: Literal["direct_control", "observer", "flashback"]
+    objective: str
+    success_state: str
+    failure_state: Optional[str] = None
+    branching_tags: Optional[List[str]] = None
+    clue_ids: Optional[List[str]] = None
+    puzzle: Optional[Puzzle] = None
+    ambience_notes: Optional[str] = None
+
+
+class Events(BaseModel):
+    events: List[Event]
+
+
+_schema_dir = Path(__file__).resolve().parent
+_schema_path = _schema_dir / "events.schema.json"
+_schema_path.write_text(json.dumps(Events.model_json_schema(), indent=2))

--- a/core/rpggen/models/events.schema.json
+++ b/core/rpggen/models/events.schema.json
@@ -1,0 +1,240 @@
+{
+  "$defs": {
+    "Event": {
+      "properties": {
+        "id": {
+          "pattern": "^E-\\d{2}-\\d{2}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "beat_id": {
+          "title": "Beat Id",
+          "type": "string"
+        },
+        "order": {
+          "exclusiveMinimum": 0,
+          "title": "Order",
+          "type": "integer"
+        },
+        "scene_type": {
+          "enum": [
+            "dialogue",
+            "investigation",
+            "action",
+            "cinematic",
+            "flashback"
+          ],
+          "title": "Scene Type",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "synopsis": {
+          "maxLength": 120,
+          "minLength": 40,
+          "title": "Synopsis",
+          "type": "string"
+        },
+        "location": {
+          "title": "Location",
+          "type": "string"
+        },
+        "absolute_ts": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Absolute Ts"
+        },
+        "characters": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Characters",
+          "type": "array"
+        },
+        "npcs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Npcs"
+        },
+        "player_role": {
+          "enum": [
+            "direct_control",
+            "observer",
+            "flashback"
+          ],
+          "title": "Player Role",
+          "type": "string"
+        },
+        "objective": {
+          "title": "Objective",
+          "type": "string"
+        },
+        "success_state": {
+          "title": "Success State",
+          "type": "string"
+        },
+        "failure_state": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Failure State"
+        },
+        "branching_tags": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Branching Tags"
+        },
+        "clue_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Clue Ids"
+        },
+        "puzzle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Puzzle"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "ambience_notes": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ambience Notes"
+        }
+      },
+      "required": [
+        "id",
+        "beat_id",
+        "order",
+        "scene_type",
+        "title",
+        "synopsis",
+        "location",
+        "characters",
+        "player_role",
+        "objective",
+        "success_state"
+      ],
+      "title": "Event",
+      "type": "object"
+    },
+    "Puzzle": {
+      "properties": {
+        "id": {
+          "pattern": "^PUZ-\\d{3}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "puzzle_type": {
+          "enum": [
+            "logic",
+            "pattern",
+            "riddle",
+            "skill"
+          ],
+          "title": "Puzzle Type",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "solution": {
+          "title": "Solution",
+          "type": "string"
+        },
+        "reward_clue": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reward Clue"
+        }
+      },
+      "required": [
+        "id",
+        "puzzle_type",
+        "description",
+        "solution"
+      ],
+      "title": "Puzzle",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "events": {
+      "items": {
+        "$ref": "#/$defs/Event"
+      },
+      "title": "Events",
+      "type": "array"
+    }
+  },
+  "required": [
+    "events"
+  ],
+  "title": "Events",
+  "type": "object"
+}

--- a/core/rpggen/models/faction.schema.json
+++ b/core/rpggen/models/faction.schema.json
@@ -1,0 +1,49 @@
+{
+  "properties": {
+    "id": {
+      "pattern": "^[a-z0-9_]+$",
+      "title": "Id",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "motive": {
+      "title": "Motive",
+      "type": "string"
+    },
+    "doctrine": {
+      "title": "Doctrine",
+      "type": "string"
+    },
+    "status": {
+      "enum": [
+        "active",
+        "dormant",
+        "destroyed"
+      ],
+      "title": "Status",
+      "type": "string"
+    },
+    "founding_year": {
+      "title": "Founding Year",
+      "type": "integer"
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "motive",
+    "doctrine",
+    "status",
+    "founding_year",
+    "description"
+  ],
+  "title": "Faction",
+  "type": "object"
+}

--- a/core/rpggen/models/flow.py
+++ b/core/rpggen/models/flow.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from pydantic import BaseModel, Field, constr
+from typing import Dict, List, Literal, Optional
+
+__all__ = ["Condition", "Transition", "NarrativeFlow"]
+
+
+class Condition(BaseModel):
+    expression: str
+    required_clues: Optional[List[str]] = None
+    required_events: Optional[List[str]] = None
+
+
+class Transition(BaseModel):
+    id: constr(pattern=r"^TR-[0-9A-F]{8}$")
+    from_event: str
+    to_event: str
+    condition: Optional[Condition] = None
+
+
+class NarrativeFlow(BaseModel):
+    flow_mode: Literal["linear", "branching-tree", "hub-spoke"]
+    default_pov: Literal["single_character", "multi_character", "omniscient"]
+    entry_event: str
+    end_events: List[str]
+    timeline_order: List[str]
+    pov_map: Dict[str, str]
+    transitions: List[Transition]
+
+
+_schema_dir = Path(__file__).resolve().parent
+_schema_path = _schema_dir / "narrative_flow.schema.json"
+_schema_path.write_text(json.dumps(NarrativeFlow.model_json_schema(), indent=2))

--- a/core/rpggen/models/historical_event.schema.json
+++ b/core/rpggen/models/historical_event.schema.json
@@ -1,0 +1,23 @@
+{
+  "properties": {
+    "year": {
+      "title": "Year",
+      "type": "integer"
+    },
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    }
+  },
+  "required": [
+    "year",
+    "title",
+    "description"
+  ],
+  "title": "HistoricalEvent",
+  "type": "object"
+}

--- a/core/rpggen/models/narrative_flow.schema.json
+++ b/core/rpggen/models/narrative_flow.schema.json
@@ -1,0 +1,145 @@
+{
+  "$defs": {
+    "Condition": {
+      "properties": {
+        "expression": {
+          "title": "Expression",
+          "type": "string"
+        },
+        "required_clues": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Required Clues"
+        },
+        "required_events": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Required Events"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "Condition",
+      "type": "object"
+    },
+    "Transition": {
+      "properties": {
+        "id": {
+          "pattern": "^TR-[0-9A-F]{8}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "from_event": {
+          "title": "From Event",
+          "type": "string"
+        },
+        "to_event": {
+          "title": "To Event",
+          "type": "string"
+        },
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Condition"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "id",
+        "from_event",
+        "to_event"
+      ],
+      "title": "Transition",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "flow_mode": {
+      "enum": [
+        "linear",
+        "branching-tree",
+        "hub-spoke"
+      ],
+      "title": "Flow Mode",
+      "type": "string"
+    },
+    "default_pov": {
+      "enum": [
+        "single_character",
+        "multi_character",
+        "omniscient"
+      ],
+      "title": "Default Pov",
+      "type": "string"
+    },
+    "entry_event": {
+      "title": "Entry Event",
+      "type": "string"
+    },
+    "end_events": {
+      "items": {
+        "type": "string"
+      },
+      "title": "End Events",
+      "type": "array"
+    },
+    "timeline_order": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Timeline Order",
+      "type": "array"
+    },
+    "pov_map": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "title": "Pov Map",
+      "type": "object"
+    },
+    "transitions": {
+      "items": {
+        "$ref": "#/$defs/Transition"
+      },
+      "title": "Transitions",
+      "type": "array"
+    }
+  },
+  "required": [
+    "flow_mode",
+    "default_pov",
+    "entry_event",
+    "end_events",
+    "timeline_order",
+    "pov_map",
+    "transitions"
+  ],
+  "title": "NarrativeFlow",
+  "type": "object"
+}

--- a/core/rpggen/models/notable_figure.schema.json
+++ b/core/rpggen/models/notable_figure.schema.json
@@ -1,0 +1,52 @@
+{
+  "properties": {
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "faction_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Faction Id"
+    },
+    "role": {
+      "title": "Role",
+      "type": "string"
+    },
+    "birth": {
+      "title": "Birth",
+      "type": "integer"
+    },
+    "death": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Death"
+    },
+    "biography": {
+      "title": "Biography",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "role",
+    "birth",
+    "biography"
+  ],
+  "title": "NotableFigure",
+  "type": "object"
+}

--- a/core/rpggen/models/plot.py
+++ b/core/rpggen/models/plot.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from pydantic import BaseModel, Field, conlist
+from typing import List, Literal, Optional
+
+__all__ = ["Beat", "PlotOutline", "ConflictType"]
+
+ConflictType = Literal[
+    "mystery",
+    "investigation",
+    "heist",
+    "pursuit",
+    "revelation",
+    "confrontation",
+    "escape",
+    "betrayal",
+]
+
+
+class Beat(BaseModel):
+    id: str = Field(..., pattern=r"^B\d{2}$")
+    order: int
+    title: str
+    summary: str = Field(..., min_length=40, max_length=120)
+    protagonists: conlist(str, min_length=1, max_length=3)
+    antagonists: Optional[conlist(str, min_length=1, max_length=3)] = None
+    location: Optional[str] = None
+    timestamp: Optional[str] = None
+    conflict_type: ConflictType
+    stakes: str
+    clue_introduced: Optional[List[str]] = None
+    foreshadow: Optional[str] = None
+    is_twist: bool
+    tension_level: int = Field(..., ge=1, le=10)
+    dependencies: Optional[List[str]] = None
+
+
+class PlotOutline(BaseModel):
+    theme: str
+    structure_mode: Literal["three_act", "kishotenketsu", "linear"]
+    beats: List[Beat]
+    pacing_curve: Optional[List[int]] = None
+
+
+_schema_dir = Path(__file__).resolve().parent
+_schema_path = _schema_dir / "plot_outline.schema.json"
+_schema_path.write_text(json.dumps(PlotOutline.model_json_schema(), indent=2))

--- a/core/rpggen/models/plot_outline.schema.json
+++ b/core/rpggen/models/plot_outline.schema.json
@@ -1,0 +1,204 @@
+{
+  "$defs": {
+    "Beat": {
+      "properties": {
+        "id": {
+          "pattern": "^B\\d{2}$",
+          "title": "Id",
+          "type": "string"
+        },
+        "order": {
+          "title": "Order",
+          "type": "integer"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "summary": {
+          "maxLength": 120,
+          "minLength": 40,
+          "title": "Summary",
+          "type": "string"
+        },
+        "protagonists": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 3,
+          "minItems": 1,
+          "title": "Protagonists",
+          "type": "array"
+        },
+        "antagonists": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 3,
+              "minItems": 1,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Antagonists"
+        },
+        "location": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Location"
+        },
+        "timestamp": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Timestamp"
+        },
+        "conflict_type": {
+          "enum": [
+            "mystery",
+            "investigation",
+            "heist",
+            "pursuit",
+            "revelation",
+            "confrontation",
+            "escape",
+            "betrayal"
+          ],
+          "title": "Conflict Type",
+          "type": "string"
+        },
+        "stakes": {
+          "title": "Stakes",
+          "type": "string"
+        },
+        "clue_introduced": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Clue Introduced"
+        },
+        "foreshadow": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Foreshadow"
+        },
+        "is_twist": {
+          "title": "Is Twist",
+          "type": "boolean"
+        },
+        "tension_level": {
+          "maximum": 10,
+          "minimum": 1,
+          "title": "Tension Level",
+          "type": "integer"
+        },
+        "dependencies": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dependencies"
+        }
+      },
+      "required": [
+        "id",
+        "order",
+        "title",
+        "summary",
+        "protagonists",
+        "conflict_type",
+        "stakes",
+        "is_twist",
+        "tension_level"
+      ],
+      "title": "Beat",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "theme": {
+      "title": "Theme",
+      "type": "string"
+    },
+    "structure_mode": {
+      "enum": [
+        "three_act",
+        "kishotenketsu",
+        "linear"
+      ],
+      "title": "Structure Mode",
+      "type": "string"
+    },
+    "beats": {
+      "items": {
+        "$ref": "#/$defs/Beat"
+      },
+      "title": "Beats",
+      "type": "array"
+    },
+    "pacing_curve": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Pacing Curve"
+    }
+  },
+  "required": [
+    "theme",
+    "structure_mode",
+    "beats"
+  ],
+  "title": "PlotOutline",
+  "type": "object"
+}

--- a/core/rpggen/models/relation.py
+++ b/core/rpggen/models/relation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from pydantic import BaseModel, Field, conlist, confloat
+from typing import List, Literal, Optional
+
+
+__all__ = ["Relation", "Relations", "RelationType"]
+
+RelationType = Literal[
+    "mentor",
+    "rival",
+    "ally",
+    "family",
+    "betrayal",
+    "employer",
+    "client",
+    "unknown",
+]
+
+
+class Relation(BaseModel):
+    id: str = Field(..., pattern="^[a-z0-9_]+$")
+    source_id: str
+    target_id: str
+    type: RelationType
+    direction: Literal["directed", "undirected"]
+    start_year: Optional[int] = None
+    end_year: Optional[int] = None
+    secrecy_level: Literal["public", "private", "secret"]
+    confidence: confloat(ge=0, le=1)
+    description: str = Field(..., min_length=60, max_length=120)
+    evidence_seeds: Optional[conlist(str, max_length=4)] = None
+
+
+class Relations(BaseModel):
+    relations: List[Relation]
+
+
+_schema_dir = Path(__file__).resolve().parent
+_schema_path = _schema_dir / "relations.schema.json"
+_schema_path.write_text(json.dumps(Relations.model_json_schema(), indent=2))

--- a/core/rpggen/models/relations.schema.json
+++ b/core/rpggen/models/relations.schema.json
@@ -1,0 +1,130 @@
+{
+  "$defs": {
+    "Relation": {
+      "properties": {
+        "id": {
+          "pattern": "^[a-z0-9_]+$",
+          "title": "Id",
+          "type": "string"
+        },
+        "source_id": {
+          "title": "Source Id",
+          "type": "string"
+        },
+        "target_id": {
+          "title": "Target Id",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "mentor",
+            "rival",
+            "ally",
+            "family",
+            "betrayal",
+            "employer",
+            "client",
+            "unknown"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "direction": {
+          "enum": [
+            "directed",
+            "undirected"
+          ],
+          "title": "Direction",
+          "type": "string"
+        },
+        "start_year": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Start Year"
+        },
+        "end_year": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "End Year"
+        },
+        "secrecy_level": {
+          "enum": [
+            "public",
+            "private",
+            "secret"
+          ],
+          "title": "Secrecy Level",
+          "type": "string"
+        },
+        "confidence": {
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Confidence",
+          "type": "number"
+        },
+        "description": {
+          "maxLength": 120,
+          "minLength": 60,
+          "title": "Description",
+          "type": "string"
+        },
+        "evidence_seeds": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 4,
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Evidence Seeds"
+        }
+      },
+      "required": [
+        "id",
+        "source_id",
+        "target_id",
+        "type",
+        "direction",
+        "secrecy_level",
+        "confidence",
+        "description"
+      ],
+      "title": "Relation",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "relations": {
+      "items": {
+        "$ref": "#/$defs/Relation"
+      },
+      "title": "Relations",
+      "type": "array"
+    }
+  },
+  "required": [
+    "relations"
+  ],
+  "title": "Relations",
+  "type": "object"
+}

--- a/core/rpggen/models/script.py
+++ b/core/rpggen/models/script.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from pydantic import BaseModel, Field, conlist
+from typing import List, Literal, Optional
+
+__all__ = [
+    "DialogueLine",
+    "PuzzleText",
+    "ScriptMeta",
+    "EventScript",
+    "ScriptsPackage",
+]
+
+
+class DialogueLine(BaseModel):
+    speaker_id: str
+    text: str
+    emotion: Optional[str] = ""
+    branch_tag: Optional[str] = ""
+
+
+class PuzzleText(BaseModel):
+    puzzle_id: str = Field(..., pattern=r"^PUZ-\d{3}$")
+    hint_success: str
+    hint_failure: str
+    reward_clue_copy: Optional[str] = None
+
+
+class ScriptMeta(BaseModel):
+    event_id: str
+    lang: Literal["zh_CN", "en_US", "jp_JP"]
+    pov: str
+    scene_type: str
+    branch_root: Optional[str] = None
+    word_count_est: int
+
+
+class EventScript(BaseModel):
+    meta: ScriptMeta
+    dialogues: conlist(DialogueLine, min_length=1)
+    puzzle_text: Optional[PuzzleText] = None
+    stage_notes: Optional[str] = None
+
+
+class ScriptsPackage(BaseModel):
+    scripts: List[EventScript]
+
+
+_schema_dir = Path(__file__).resolve().parent
+_schema_path = _schema_dir / "scripts.schema.json"
+_schema_path.write_text(json.dumps(ScriptsPackage.model_json_schema(), indent=2))

--- a/core/rpggen/models/scripts.schema.json
+++ b/core/rpggen/models/scripts.schema.json
@@ -1,0 +1,190 @@
+{
+  "$defs": {
+    "DialogueLine": {
+      "properties": {
+        "speaker_id": {
+          "title": "Speaker Id",
+          "type": "string"
+        },
+        "text": {
+          "title": "Text",
+          "type": "string"
+        },
+        "emotion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "",
+          "title": "Emotion"
+        },
+        "branch_tag": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "",
+          "title": "Branch Tag"
+        }
+      },
+      "required": [
+        "speaker_id",
+        "text"
+      ],
+      "title": "DialogueLine",
+      "type": "object"
+    },
+    "EventScript": {
+      "properties": {
+        "meta": {
+          "$ref": "#/$defs/ScriptMeta"
+        },
+        "dialogues": {
+          "items": {
+            "$ref": "#/$defs/DialogueLine"
+          },
+          "minItems": 1,
+          "title": "Dialogues",
+          "type": "array"
+        },
+        "puzzle_text": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PuzzleText"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "stage_notes": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Stage Notes"
+        }
+      },
+      "required": [
+        "meta",
+        "dialogues"
+      ],
+      "title": "EventScript",
+      "type": "object"
+    },
+    "PuzzleText": {
+      "properties": {
+        "puzzle_id": {
+          "pattern": "^PUZ-\\d{3}$",
+          "title": "Puzzle Id",
+          "type": "string"
+        },
+        "hint_success": {
+          "title": "Hint Success",
+          "type": "string"
+        },
+        "hint_failure": {
+          "title": "Hint Failure",
+          "type": "string"
+        },
+        "reward_clue_copy": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reward Clue Copy"
+        }
+      },
+      "required": [
+        "puzzle_id",
+        "hint_success",
+        "hint_failure"
+      ],
+      "title": "PuzzleText",
+      "type": "object"
+    },
+    "ScriptMeta": {
+      "properties": {
+        "event_id": {
+          "title": "Event Id",
+          "type": "string"
+        },
+        "lang": {
+          "enum": [
+            "zh_CN",
+            "en_US",
+            "jp_JP"
+          ],
+          "title": "Lang",
+          "type": "string"
+        },
+        "pov": {
+          "title": "Pov",
+          "type": "string"
+        },
+        "scene_type": {
+          "title": "Scene Type",
+          "type": "string"
+        },
+        "branch_root": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Branch Root"
+        },
+        "word_count_est": {
+          "title": "Word Count Est",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "event_id",
+        "lang",
+        "pov",
+        "scene_type",
+        "word_count_est"
+      ],
+      "title": "ScriptMeta",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "scripts": {
+      "items": {
+        "$ref": "#/$defs/EventScript"
+      },
+      "title": "Scripts",
+      "type": "array"
+    }
+  },
+  "required": [
+    "scripts"
+  ],
+  "title": "ScriptsPackage",
+  "type": "object"
+}

--- a/core/rpggen/models/special_energy.schema.json
+++ b/core/rpggen/models/special_energy.schema.json
@@ -1,0 +1,65 @@
+{
+  "properties": {
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "discovery_year": {
+      "title": "Discovery Year",
+      "type": "integer"
+    },
+    "physical_form": {
+      "enum": [
+        "plasma",
+        "crystal",
+        "field",
+        "organism"
+      ],
+      "title": "Physical Form",
+      "type": "string"
+    },
+    "properties": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Properties"
+    },
+    "hazards": {
+      "items": {
+        "type": "string"
+      },
+      "title": "Hazards",
+      "type": "array"
+    },
+    "applications": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Applications"
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "discovery_year",
+    "physical_form",
+    "properties",
+    "hazards",
+    "description"
+  ],
+  "title": "SpecialEnergy",
+  "type": "object"
+}

--- a/core/rpggen/models/technology.schema.json
+++ b/core/rpggen/models/technology.schema.json
@@ -1,0 +1,34 @@
+{
+  "properties": {
+    "id": {
+      "pattern": "^[a-z0-9_]+$",
+      "title": "Id",
+      "type": "string"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "era": {
+      "enum": [
+        "experimental",
+        "early",
+        "mature"
+      ],
+      "title": "Era",
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "era",
+    "description"
+  ],
+  "title": "Technology",
+  "type": "object"
+}

--- a/core/rpggen/models/world.py
+++ b/core/rpggen/models/world.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from pydantic import BaseModel, Field
+from typing import List, Literal, Optional
+
+
+__all__ = [
+    "Technology",
+    "SpecialEnergy",
+    "Faction",
+    "HistoricalEvent",
+    "NotableFigure",
+    "World",
+]
+
+
+class Technology(BaseModel):
+    id: str = Field(..., pattern="^[a-z0-9_]+$")
+    name: str
+    era: Literal["experimental", "early", "mature"]
+    description: str
+
+
+class SpecialEnergy(BaseModel):
+    name: str
+    discovery_year: int
+    physical_form: Literal["plasma", "crystal", "field", "organism"]
+    properties: List[str]
+    hazards: List[str]
+    applications: Optional[List[str]] = None
+    description: str
+
+
+class Faction(BaseModel):
+    id: str = Field(..., pattern="^[a-z0-9_]+$")
+    name: str
+    motive: str
+    doctrine: str
+    status: Literal["active", "dormant", "destroyed"]
+    founding_year: int
+    description: str
+
+
+class HistoricalEvent(BaseModel):
+    year: int
+    title: str
+    description: str
+
+
+class NotableFigure(BaseModel):
+    name: str
+    faction_id: Optional[str] = None
+    role: str
+    birth: int
+    death: Optional[int] = None
+    biography: str
+
+
+class World(BaseModel):
+    setting: str
+    global_theme: str
+    technologies: List[Technology]
+    special_energy: SpecialEnergy
+    factions: List[Faction]
+    historical_timeline: List[HistoricalEvent]
+    notable_figures: List[NotableFigure]
+
+
+# Auto export JSON schema for each primary model
+
+_schema_dir = Path(__file__).resolve().parent
+
+for model_cls, name in [
+    (World, "world"),
+    (Technology, "technology"),
+    (SpecialEnergy, "special_energy"),
+    (Faction, "faction"),
+    (HistoricalEvent, "historical_event"),
+    (NotableFigure, "notable_figure"),
+]:
+    schema_path = _schema_dir / f"{name}.schema.json"
+    schema_path.write_text(
+        json.dumps(model_cls.model_json_schema(), indent=2)
+    )

--- a/core/rpggen/models/world.schema.json
+++ b/core/rpggen/models/world.schema.json
@@ -1,0 +1,279 @@
+{
+  "$defs": {
+    "Faction": {
+      "properties": {
+        "id": {
+          "pattern": "^[a-z0-9_]+$",
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "motive": {
+          "title": "Motive",
+          "type": "string"
+        },
+        "doctrine": {
+          "title": "Doctrine",
+          "type": "string"
+        },
+        "status": {
+          "enum": [
+            "active",
+            "dormant",
+            "destroyed"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "founding_year": {
+          "title": "Founding Year",
+          "type": "integer"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "motive",
+        "doctrine",
+        "status",
+        "founding_year",
+        "description"
+      ],
+      "title": "Faction",
+      "type": "object"
+    },
+    "HistoricalEvent": {
+      "properties": {
+        "year": {
+          "title": "Year",
+          "type": "integer"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        }
+      },
+      "required": [
+        "year",
+        "title",
+        "description"
+      ],
+      "title": "HistoricalEvent",
+      "type": "object"
+    },
+    "NotableFigure": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "faction_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Faction Id"
+        },
+        "role": {
+          "title": "Role",
+          "type": "string"
+        },
+        "birth": {
+          "title": "Birth",
+          "type": "integer"
+        },
+        "death": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Death"
+        },
+        "biography": {
+          "title": "Biography",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "role",
+        "birth",
+        "biography"
+      ],
+      "title": "NotableFigure",
+      "type": "object"
+    },
+    "SpecialEnergy": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "discovery_year": {
+          "title": "Discovery Year",
+          "type": "integer"
+        },
+        "physical_form": {
+          "enum": [
+            "plasma",
+            "crystal",
+            "field",
+            "organism"
+          ],
+          "title": "Physical Form",
+          "type": "string"
+        },
+        "properties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Properties"
+        },
+        "hazards": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Hazards",
+          "type": "array"
+        },
+        "applications": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Applications"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "discovery_year",
+        "physical_form",
+        "properties",
+        "hazards",
+        "description"
+      ],
+      "title": "SpecialEnergy",
+      "type": "object"
+    },
+    "Technology": {
+      "properties": {
+        "id": {
+          "pattern": "^[a-z0-9_]+$",
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "era": {
+          "enum": [
+            "experimental",
+            "early",
+            "mature"
+          ],
+          "title": "Era",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "era",
+        "description"
+      ],
+      "title": "Technology",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "setting": {
+      "title": "Setting",
+      "type": "string"
+    },
+    "global_theme": {
+      "title": "Global Theme",
+      "type": "string"
+    },
+    "technologies": {
+      "items": {
+        "$ref": "#/$defs/Technology"
+      },
+      "title": "Technologies",
+      "type": "array"
+    },
+    "special_energy": {
+      "$ref": "#/$defs/SpecialEnergy"
+    },
+    "factions": {
+      "items": {
+        "$ref": "#/$defs/Faction"
+      },
+      "title": "Factions",
+      "type": "array"
+    },
+    "historical_timeline": {
+      "items": {
+        "$ref": "#/$defs/HistoricalEvent"
+      },
+      "title": "Historical Timeline",
+      "type": "array"
+    },
+    "notable_figures": {
+      "items": {
+        "$ref": "#/$defs/NotableFigure"
+      },
+      "title": "Notable Figures",
+      "type": "array"
+    }
+  },
+  "required": [
+    "setting",
+    "global_theme",
+    "technologies",
+    "special_energy",
+    "factions",
+    "historical_timeline",
+    "notable_figures"
+  ],
+  "title": "World",
+  "type": "object"
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,9 @@
+import sys
+from pathlib import Path
+
+# Ensure core package is importable during tests
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "core"))
+
 from rpggen import main
 
 def test_main_output(capsys):


### PR DESCRIPTION
## Summary
- implement Pydantic models for world, characters, relations and more
- export JSON schemas alongside the models
- expose models via `rpggen` package
- adjust tests to import the package directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c5016d6c8324b2bf65f385a7c89e