### PR TITLE
Implement OpenRouter LLM client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENROUTER_API_KEY=your-api-key
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+OPENROUTER_MODEL=qwen/qwen3-30b-a3b:free

--- a/README.md
+++ b/README.md
@@ -7,3 +7,22 @@ This repository hosts the development of a logic-driven suspense RPG generator.
 /webui  - Next.js frontend (placeholder)
 /docs   - Project documentation
 ```
+
+## LLM Client
+
+The backend exposes a small wrapper `OpenRouterClient` in `rpggen.llm_client`. It
+uses [LangChain](https://python.langchain.com/) to talk to the OpenRouter API and
+supports automatic retries and optional streaming output.
+
+```python
+from rpggen.llm_client import OpenRouterClient
+
+# will read OPENROUTER_* variables from .env
+client = OpenRouterClient(streaming=True)
+for token in client.stream("Hello world"):
+    ...  # handle streamed tokens
+```
+
+Create a ``.env`` file based on ``.env.example`` to configure
+``OPENROUTER_API_KEY``, ``OPENROUTER_BASE_URL`` and ``OPENROUTER_MODEL``.
+

--- a/core/rpggen/__init__.py
+++ b/core/rpggen/__init__.py
@@ -2,5 +2,7 @@ from __future__ import annotations
 
 from .cli import main
 from . import models
+from .llm_client import OpenRouterClient
 
-__all__ = ["main", "models"] + list(models.__all__)
+__all__ = ["main", "models", "OpenRouterClient"] + list(models.__all__)
+

--- a/core/rpggen/llm_client.py
+++ b/core/rpggen/llm_client.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+"""Unified OpenRouter LLM client using LangChain.
+
+Environment variables are loaded from a ``.env`` file if present.
+"""
+
+from typing import Iterable, Optional
+import os
+
+from dotenv import load_dotenv
+
+# load variables from a local .env file if present
+load_dotenv()
+
+from langchain_openai import ChatOpenAI
+from langchain_core.runnables import Runnable
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
+
+__all__ = ["OpenRouterClient"]
+
+
+class OpenRouterClient:
+    """Simple wrapper around :class:`~langchain_openai.ChatOpenAI`.
+
+    Parameters
+    ----------
+    model:
+        Model name to call on OpenRouter. Defaults to ``OPENROUTER_MODEL`` or
+        ``qwen/qwen3-30b-a3b:free``.
+    max_retries:
+        Number of attempts before giving up.
+    streaming:
+        Whether to enable streaming output. When enabled the response tokens
+        are printed to stdout via ``StreamingStdOutCallbackHandler``.
+    base_url:
+        Override OpenRouter endpoint. Defaults to ``OPENROUTER_BASE_URL`` or
+        ``https://openrouter.ai/api/v1``.
+    api_key:
+        API key used for authentication. Defaults to ``OPENROUTER_API_KEY``.
+    **kwargs:
+        Extra arguments forwarded to :class:`ChatOpenAI`.
+    """
+
+    def __init__(
+        self,
+        model: Optional[str] = None,
+        *,
+        max_retries: int = 2,
+        streaming: bool = False,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        **kwargs: object,
+    ) -> None:
+        if model is None:
+            model = os.environ.get("OPENROUTER_MODEL", "qwen/qwen3-30b-a3b:free")
+        if base_url is None:
+            base_url = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+        if api_key is None:
+            api_key = os.environ.get("OPENROUTER_API_KEY")
+
+        callbacks = kwargs.pop("callbacks", None)
+        if streaming and callbacks is None:
+            callbacks = [StreamingStdOutCallbackHandler()]
+
+        self._llm: Runnable = ChatOpenAI(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            streaming=streaming,
+            callbacks=callbacks,
+            **kwargs,
+        ).with_retry(stop_after_attempt=max_retries)
+
+        self._parser = StrOutputParser()
+
+    def invoke(self, prompt: str) -> str:
+        """Invoke the model with the given prompt and return the full text."""
+        chain = self._llm | self._parser
+        return chain.invoke(prompt)
+
+    def stream(self, prompt: str) -> Iterable[str]:
+        """Yield the streamed tokens for the given prompt."""
+        llm = self._llm
+        if not getattr(llm, "streaming", False):
+            yield self.invoke(prompt)
+            return
+        for chunk in llm.stream(prompt):
+            if hasattr(chunk, "content"):
+                yield chunk.content
+            else:
+                yield str(chunk)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ numpy = "*"
 networkx = "*"
 fastapi = "*"
 uvicorn = "*"
+python-dotenv = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+
+# Make core package importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "core"))
+
+import rpggen
+from rpggen.llm_client import OpenRouterClient
+
+
+def test_openrouterclient_invoke(monkeypatch):
+    from langchain_community.llms import FakeListLLM
+
+    captured = {}
+
+    def fake_chat_openai(*args, **kwargs):
+        captured.update(kwargs)
+        return FakeListLLM(responses=["ok"])
+
+    monkeypatch.setattr("rpggen.llm_client.ChatOpenAI", fake_chat_openai)
+    monkeypatch.setenv("OPENROUTER_MODEL", "env-model")
+    monkeypatch.setenv("OPENROUTER_BASE_URL", "https://example.com")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+
+    client = OpenRouterClient()
+    assert client.invoke("test") == "ok"
+    assert captured["model"] == "env-model"
+    assert captured["base_url"] == "https://example.com"
+    assert captured["api_key"] == "sk-test"
+


### PR DESCRIPTION
## Summary
- add environment-aware OpenRouter client using LangChain
- load model, base URL and API key via `.env`
- document environment variables in README
- provide `.env.example`
- test client initialization with env overrides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858c79af5088324adfaffb848ed3c88