### PR TITLE
Add missing dependencies to pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ rpggen = "rpggen.cli:main"
 python = "^3.12"
 pydantic = "^2.11.7"
 langchain = "*"
+langchain-openai = "*"
+langchain-community = "*"
 typer = "*"
 pyyaml = "*"
 jinja2 = "*"
@@ -24,7 +26,7 @@ fastapi = "*"
 uvicorn = "*"
 python-dotenv = "*"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "*"
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `langchain-openai` and `langchain-community` packages
- move dev deps to `[tool.poetry.group.dev.dependencies]`

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e46fc1d0832484b42847cb3825a2