### PR TITLE
Add CI skeleton

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,15 @@ jobs:
         with:
           python-version: '3.12'
       - uses: snok/install-poetry@v1
+      - name: Cache poetry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-poetry-
       - run: poetry install --no-interaction
-      - run: poetry run pytest -v
+      - run: poetry run ruff check core tests scripts
+      - run: poetry run python scripts/check_schemas.py
+      - run: poetry run pytest -m "not slow" -v

--- a/README.md
+++ b/README.md
@@ -60,3 +60,15 @@ uid = hash_id("some text")
 logger = get_logger("demo")
 ```
 
+## Development
+
+Run lint and tests using Poetry:
+
+```bash
+poetry run ruff check core tests scripts
+poetry run pytest -m "not slow" -v
+```
+
+The CI workflow also verifies that JSON schema files are up to date by running
+`scripts/check_schemas.py`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ python-dotenv = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
+ruff = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+line-length = 88
+target-version = "py312"
+
+[lint]
+select = ["E", "F"]
+ignore = ["E402", "F403", "E501", "F401"]

--- a/scripts/check_schemas.py
+++ b/scripts/check_schemas.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""Validate that generated JSON schemas are committed."""
+import subprocess
+from pathlib import Path
+
+
+def main() -> int:
+    # Importing rpggen.models will regenerate schema files in-place
+    import rpggen.models  # noqa: F401
+
+    repo = Path(__file__).resolve().parents[1]
+    schema_dir = repo / "core" / "rpggen" / "models"
+    schema_files = sorted(schema_dir.glob("*.schema.json"))
+
+    if not schema_files:
+        print("No schema files found", flush=True)
+        return 0
+
+    result = subprocess.run(["git", "diff", "--name-only", "--exit-code", "--"] + [str(f) for f in schema_files])
+    if result.returncode != 0:
+        print("Schema files are out of date. Run tests to regenerate and commit them.", flush=True)
+        return result.returncode
+    print("Schemas up to date.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add ruff as dev dependency and config
- include schema check script
- update README with development section
- extend CI workflow with linting, schema diff and cache
- refresh generated JSON schema files

## Testing
- `poetry run ruff check core tests scripts`
- `poetry run python scripts/check_schemas.py` (fails when schemas outdated)
- `poetry run pytest -m "not slow" -v`


------
https://chatgpt.com/codex/tasks/task_e_6858f515cc348324a854e18335298c9a