### PR TITLE
Fix schema generation newline

### DIFF
--- a/core/rpggen/models/character.py
+++ b/core/rpggen/models/character.py
@@ -32,4 +32,4 @@ class Character(BaseModel):
 
 _schema_dir = Path(__file__).resolve().parent
 _schema_path = _schema_dir / "characters.schema.json"
-_schema_path.write_text(json.dumps(Character.model_json_schema(), indent=2))
+_schema_path.write_text(json.dumps(Character.model_json_schema(), indent=2) + "\n")

--- a/core/rpggen/models/event.py
+++ b/core/rpggen/models/event.py
@@ -51,4 +51,4 @@ class Events(BaseModel):
 
 _schema_dir = Path(__file__).resolve().parent
 _schema_path = _schema_dir / "events.schema.json"
-_schema_path.write_text(json.dumps(Events.model_json_schema(), indent=2))
+_schema_path.write_text(json.dumps(Events.model_json_schema(), indent=2) + "\n")

--- a/core/rpggen/models/flow.py
+++ b/core/rpggen/models/flow.py
@@ -33,4 +33,4 @@ class NarrativeFlow(BaseModel):
 
 _schema_dir = Path(__file__).resolve().parent
 _schema_path = _schema_dir / "narrative_flow.schema.json"
-_schema_path.write_text(json.dumps(NarrativeFlow.model_json_schema(), indent=2))
+_schema_path.write_text(json.dumps(NarrativeFlow.model_json_schema(), indent=2) + "\n")

--- a/core/rpggen/models/plot.py
+++ b/core/rpggen/models/plot.py
@@ -46,4 +46,4 @@ class PlotOutline(BaseModel):
 
 _schema_dir = Path(__file__).resolve().parent
 _schema_path = _schema_dir / "plot_outline.schema.json"
-_schema_path.write_text(json.dumps(PlotOutline.model_json_schema(), indent=2))
+_schema_path.write_text(json.dumps(PlotOutline.model_json_schema(), indent=2) + "\n")

--- a/core/rpggen/models/relation.py
+++ b/core/rpggen/models/relation.py
@@ -40,4 +40,4 @@ class Relations(BaseModel):
 
 _schema_dir = Path(__file__).resolve().parent
 _schema_path = _schema_dir / "relations.schema.json"
-_schema_path.write_text(json.dumps(Relations.model_json_schema(), indent=2))
+_schema_path.write_text(json.dumps(Relations.model_json_schema(), indent=2) + "\n")

--- a/core/rpggen/models/script.py
+++ b/core/rpggen/models/script.py
@@ -50,4 +50,4 @@ class ScriptsPackage(BaseModel):
 
 _schema_dir = Path(__file__).resolve().parent
 _schema_path = _schema_dir / "scripts.schema.json"
-_schema_path.write_text(json.dumps(ScriptsPackage.model_json_schema(), indent=2))
+_schema_path.write_text(json.dumps(ScriptsPackage.model_json_schema(), indent=2) + "\n")

--- a/core/rpggen/models/world.py
+++ b/core/rpggen/models/world.py
@@ -82,5 +82,5 @@ for model_cls, name in [
 ]:
     schema_path = _schema_dir / f"{name}.schema.json"
     schema_path.write_text(
-        json.dumps(model_cls.model_json_schema(), indent=2)
+        json.dumps(model_cls.model_json_schema(), indent=2) + "\n"
     )


### PR DESCRIPTION
## Summary
- ensure newline is appended when auto-generating schema files

## Testing
- `poetry run ruff check .`
- `poetry run pytest -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_6858faf2e09c832487fb1607b3f3f205