### PR TITLE
Add proper noun support to world builder

### DIFF
--- a/core/rpggen/models/faction.schema.json
+++ b/core/rpggen/models/faction.schema.json
@@ -31,6 +31,7 @@
       "type": "integer"
     },
     "description": {
+      "minLength": 100,
       "title": "Description",
       "type": "string"
     }

--- a/core/rpggen/models/notable_figure.schema.json
+++ b/core/rpggen/models/notable_figure.schema.json
@@ -37,6 +37,7 @@
       "title": "Death"
     },
     "biography": {
+      "minLength": 100,
       "title": "Biography",
       "type": "string"
     }

--- a/core/rpggen/models/proper_noun.schema.json
+++ b/core/rpggen/models/proper_noun.schema.json
@@ -1,36 +1,35 @@
 {
   "properties": {
-    "id": {
-      "pattern": "^[a-z0-9_]+$",
-      "title": "Id",
-      "type": "string"
-    },
     "name": {
       "title": "Name",
       "type": "string"
     },
-    "era": {
+    "category": {
       "enum": [
-        "experimental",
-        "early",
-        "mature"
+        "technology",
+        "energy",
+        "faction",
+        "location",
+        "event",
+        "project",
+        "figure",
+        "other"
       ],
-      "title": "Era",
+      "title": "Category",
       "type": "string"
     },
     "description": {
-      "maxLength": 180,
-      "minLength": 100,
+      "maxLength": 100,
+      "minLength": 40,
       "title": "Description",
       "type": "string"
     }
   },
   "required": [
-    "id",
     "name",
-    "era",
+    "category",
     "description"
   ],
-  "title": "Technology",
+  "title": "ProperNoun",
   "type": "object"
 }

--- a/core/rpggen/models/special_energy.schema.json
+++ b/core/rpggen/models/special_energy.schema.json
@@ -48,6 +48,7 @@
       "title": "Applications"
     },
     "description": {
+      "minLength": 120,
       "title": "Description",
       "type": "string"
     }

--- a/core/rpggen/models/world.py
+++ b/core/rpggen/models/world.py
@@ -12,6 +12,7 @@ __all__ = [
     "Faction",
     "HistoricalEvent",
     "NotableFigure",
+    "ProperNoun",
     "World",
 ]
 
@@ -20,7 +21,7 @@ class Technology(BaseModel):
     id: str = Field(..., pattern="^[a-z0-9_]+$")
     name: str
     era: Literal["experimental", "early", "mature"]
-    description: str
+    description: str = Field(..., min_length=100, max_length=180)
 
 
 class SpecialEnergy(BaseModel):
@@ -30,7 +31,7 @@ class SpecialEnergy(BaseModel):
     properties: List[str]
     hazards: List[str]
     applications: Optional[List[str]] = None
-    description: str
+    description: str = Field(..., min_length=120)
 
 
 class Faction(BaseModel):
@@ -40,7 +41,7 @@ class Faction(BaseModel):
     doctrine: str
     status: Literal["active", "dormant", "destroyed"]
     founding_year: int
-    description: str
+    description: str = Field(..., min_length=100)
 
 
 class HistoricalEvent(BaseModel):
@@ -55,7 +56,22 @@ class NotableFigure(BaseModel):
     role: str
     birth: int
     death: Optional[int] = None
-    biography: str
+    biography: str = Field(..., min_length=100)
+
+
+class ProperNoun(BaseModel):
+    name: str
+    category: Literal[
+        "technology",
+        "energy",
+        "faction",
+        "location",
+        "event",
+        "project",
+        "figure",
+        "other",
+    ]
+    description: str = Field(..., min_length=40, max_length=100)
 
 
 class World(BaseModel):
@@ -66,6 +82,7 @@ class World(BaseModel):
     factions: List[Faction]
     historical_timeline: List[HistoricalEvent]
     notable_figures: List[NotableFigure]
+    proper_nouns: List[ProperNoun]
 
 
 # Auto export JSON schema for each primary model
@@ -79,6 +96,7 @@ for model_cls, name in [
     (Faction, "faction"),
     (HistoricalEvent, "historical_event"),
     (NotableFigure, "notable_figure"),
+    (ProperNoun, "proper_noun"),
 ]:
     schema_path = _schema_dir / f"{name}.schema.json"
     schema_path.write_text(

--- a/core/rpggen/models/world.schema.json
+++ b/core/rpggen/models/world.schema.json
@@ -33,6 +33,7 @@
           "type": "integer"
         },
         "description": {
+          "minLength": 100,
           "title": "Description",
           "type": "string"
         }
@@ -111,6 +112,7 @@
           "title": "Death"
         },
         "biography": {
+          "minLength": 100,
           "title": "Biography",
           "type": "string"
         }
@@ -122,6 +124,41 @@
         "biography"
       ],
       "title": "NotableFigure",
+      "type": "object"
+    },
+    "ProperNoun": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "category": {
+          "enum": [
+            "technology",
+            "energy",
+            "faction",
+            "location",
+            "event",
+            "project",
+            "figure",
+            "other"
+          ],
+          "title": "Category",
+          "type": "string"
+        },
+        "description": {
+          "maxLength": 100,
+          "minLength": 40,
+          "title": "Description",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "category",
+        "description"
+      ],
+      "title": "ProperNoun",
       "type": "object"
     },
     "SpecialEnergy": {
@@ -174,6 +211,7 @@
           "title": "Applications"
         },
         "description": {
+          "minLength": 120,
           "title": "Description",
           "type": "string"
         }
@@ -210,6 +248,8 @@
           "type": "string"
         },
         "description": {
+          "maxLength": 180,
+          "minLength": 100,
           "title": "Description",
           "type": "string"
         }
@@ -263,6 +303,13 @@
       },
       "title": "Notable Figures",
       "type": "array"
+    },
+    "proper_nouns": {
+      "items": {
+        "$ref": "#/$defs/ProperNoun"
+      },
+      "title": "Proper Nouns",
+      "type": "array"
     }
   },
   "required": [
@@ -272,7 +319,8 @@
     "special_energy",
     "factions",
     "historical_timeline",
-    "notable_figures"
+    "notable_figures",
+    "proper_nouns"
   ],
   "title": "World",
   "type": "object"

--- a/core/rpggen/runner/world_builder.py
+++ b/core/rpggen/runner/world_builder.py
@@ -40,6 +40,11 @@ class WorldBuilder(BaseNode):
             "所有文本必须使用中文，并且只能返回有效的 JSON，"
             "不要添加任何解释或多余内容。"
             "生成的描述不需要顾虑长度限制，务必详细。"
+            "所有描述字段需达到最小字数要求，"
+            "并额外生成 'proper_nouns' 专有名词表。"
+            "各字段最小字数如下：Technology.description ≥100，"
+            "SpecialEnergy.description ≥120，Faction.description ≥100，"
+            "NotableFigure.biography ≥100，ProperNoun.description 40-100。"
             "世界至少包含三大势力，并给出完整的设定说明。"
             "历史时间轴应充分展开，不能过于简短。"
             "'setting' 字段必须填写世界名称。\n"
@@ -56,14 +61,22 @@ class WorldBuilder(BaseNode):
         if not (os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")):
             # Offline fallback used during tests when no API key is configured
             stub = {
-                "setting": "stub", "global_theme": "stub", "technologies": [],
+                "setting": "stub",
+                "global_theme": "stub",
+                "technologies": [],
                 "special_energy": {
-                    "name": "stub", "discovery_year": 0,
-                    "physical_form": "field", "properties": [],
-                    "hazards": [], "applications": None, "description": ""
+                    "name": "stub",
+                    "discovery_year": 0,
+                    "physical_form": "field",
+                    "properties": [],
+                    "hazards": [],
+                    "applications": None,
+                    "description": "x" * 120,
                 },
-                "factions": [], "historical_timeline": [],
-                "notable_figures": []
+                "factions": [],
+                "historical_timeline": [],
+                "notable_figures": [],
+                "proper_nouns": []
             }
             return json.dumps(stub)
 
@@ -84,6 +97,11 @@ class WorldBuilder(BaseNode):
         ids = [f.id for f in parsed.factions]
         if len(ids) != len(set(ids)):
             self.logger.error("duplicate faction id")
+            return False
+        # proper noun names must be unique
+        names = [n.name for n in parsed.proper_nouns]
+        if len(names) != len(set(names)):
+            self.logger.error("duplicate proper noun")
             return False
         return True
 

--- a/tests/test_world_builder.py
+++ b/tests/test_world_builder.py
@@ -27,11 +27,13 @@ def test_world_builder_run(tmp_path, monkeypatch):
             "properties": [],
             "hazards": [],
             "applications": None,
-            "description": ""
+            "description": "x" * 120
         },
         "factions": [],
         "historical_timeline": [],
         "notable_figures": []
+        ,
+        "proper_nouns": []
     }
     response = json.dumps(data)
     monkeypatch.setattr(
@@ -43,4 +45,5 @@ def test_world_builder_run(tmp_path, monkeypatch):
     node = WorldBuilder(cfg)
     result = node.run()
     assert result.setting == "Test World"
+    assert result.proper_nouns == []
     assert (tmp_path / "world.json").exists()


### PR DESCRIPTION
## Summary
- expand world model with `ProperNoun` entries
- enforce minimum lengths on world description fields
- generate `proper_nouns` list in the world builder and update the prompt
- update CLI stub and consistency checks
- regenerate schemas and adjust world builder unit test

## Testing
- `ruff check .`
- `pytest -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_6859147752c88324ad2d666a5aec3e21